### PR TITLE
OK, version 0.2.2 pushed to central.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.github.stephenc</groupId>
   <artifactId>jamm</artifactId>
   <packaging>jar</packaging>
-  <version>0.2.2</version>
+  <version>0.2.3-SNAPSHOT</version>
   <name>Java Agent for Memory Measurements</name>
   <description>
     Jamm provides MemoryMeter, a java agent to measure actual object memory use including JVM overhead.


### PR DESCRIPTION
Also if you can replace the cassandra/lib version with

http://repo1.maven.org/maven2/com/github/stephenc/jamm/0.2.2/jamm-0.2.2.jar 

or if you are being really proactive and the sync has not hit 

https://oss.sonatype.org/service/local/repositories/releases/content/com/github/stephenc/jamm/0.2.2/jamm-0.2.2.jar

sha1 ee7d 0cc5 f9f8 79c0 0656 b748 7ba1 9672 c8e2 7ce0 
md5 07829fab6b45af032e061b5708cfbb3b

-----BEGIN PGP SIGNATURE-----
Version: GnuPG/MacGPG2 v2.0.16 (Darwin)

iEYEABECAAYFAk22jTsACgkQx8oZt7Yg14ecZwCfbNYdndOg93AamwQXinyXRGAi
GjYAnRj2lVy4lm96BGQ1Ls6rnm+2v7L6
=qiPo
-----END PGP SIGNATURE-----
