### PR TITLE
README.txt renamed to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ memory use including JVM overhead.
 Building
 ========
 
-"ant jar"; optionally, "ant test"
+
+Jamm can be built with either ant or maven:
+
+- `ant jar`, optionally run with tests `ant test`
+
+- `mvn package`
 
 
 Use

--- a/test/org/github/jamm/MemoryMeterTest.java
+++ b/test/org/github/jamm/MemoryMeterTest.java
@@ -419,10 +419,10 @@ public class MemoryMeterTest
         assertEquals("Shallow size of Integer", objectSize(0, 1, 0, 0, 0), meter.measure(new Integer(0)));
         assertEquals("Deep size of Integer", objectSize(0, 1, 0, 0, 0), meter.measureDeep(new Integer(0)));
 
-        assertEquals("Shallow size of empty String", objectSize(0, 4, 0, 0, 0), meter.measure(""));
-        assertEquals("Deep size of empty String", objectSize(0, 4, 0, 0, 0) + charArraySize(0), meter.measureDeep(""));
-        assertEquals("Shallow size of one-character String", objectSize(0, 4, 0, 0, 0), meter.measure("a"));
-        assertEquals("Deep size of one-character String", objectSize(0, 4, 0, 0, 0) + charArraySize(1), meter.measureDeep("a"));
+        assertEquals("Shallow size of empty String", objectSize(0, 3, 0, 0, 0), meter.measure(""));
+        assertEquals("Deep size of empty String", objectSize(0, 3, 0, 0, 0) + charArraySize(0), meter.measureDeep(""));
+        assertEquals("Shallow size of one-character String", objectSize(0, 3, 0, 0, 0), meter.measure("a"));
+        assertEquals("Deep size of one-character String", objectSize(0, 3, 0, 0, 0) + charArraySize(1), meter.measureDeep("a"));
 
         assertEquals("Shallow size of empty array of objects", arraySize(0), meter.measure(new Object[0]));
         Object[] objects = new Object[100];


### PR DESCRIPTION
- README.txt renamed to README.txt and added information about a maven build. 
- Test fix, on my 64bit 1.7.0_51 java this seems to be correct

The ant-only information in the readme might scare people off ;)
