### PR TITLE
Workaround for bug in Shenandoah when getting the memory-pool-usage f…

### DIFF
--- a/src/org/github/jamm/MemoryLayoutSpecification.java
+++ b/src/org/github/jamm/MemoryLayoutSpecification.java
@@ -204,7 +204,19 @@ public abstract class MemoryLayoutSpecification
 
             long maxMemory = 0;
             for (MemoryPoolMXBean mp : ManagementFactory.getMemoryPoolMXBeans()) {
-                maxMemory += mp.getUsage().getMax();
+                try
+                {
+                    maxMemory += mp.getUsage().getMax();
+                }
+                catch (InternalError e)
+                {
+                    if ("Shenandoah".equals(mp.getName()))
+                    {
+                        maxMemory = Long.MAX_VALUE;
+                        break;
+                    }
+                    throw e;
+                }
             }
 
             if (maxMemory < 30L * 1024 * 1024 * 1024) {


### PR DESCRIPTION
…or 'Shenandoah':

Caused by: java.lang.InternalError: Memory Pool not found
	at java.management/sun.management.MemoryPoolImpl.getUsage0(Native Method)
	at java.management/sun.management.MemoryPoolImpl.getUsage(MemoryPoolImpl.java:94)
	at org.github.jamm.MemoryLayoutSpecification.getEffectiveMemoryLayoutSpecification(MemoryLayoutSpecification.java:207)
	at org.github.jamm.MemoryLayoutSpecification.<clinit>(MemoryLayoutSpecification.java:31)