### PR TITLE
Fix output directory not created for mac tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -122,6 +122,7 @@
   </target>
 	
   <target name="test-mac" depends="checkos" if="isMac">
+    <mkdir dir="${test.out}"/>
     <echo message="Testing with modified object alignment"/>
     <junit fork="on" failureproperty="testfailed">
         <formatter type="xml" usefile="true"/>


### PR DESCRIPTION
Otherwise, `ant test` breaks with:
```
test-mac:
     [echo] Testing with modified object alignment
    [junit] Testsuite: org.github.jamm.GuessTest
    [junit] Exception in thread "main" Unable to write log file
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.XMLJUnitResultFormatter.endTestSuite(XMLJUnitResultFormatter.java:197)
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.fireEndTestSuite(JUnitTestRunner.java:853)
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:577)
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1196)
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:1041)
    [junit] Caused by: java.nio.file.NoSuchFileException: /Users/attila/Documents/projects/jamm/target/test/output/TEST-org.github.jamm.GuessTest.xml
    [junit] 	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
    [junit] 	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
    [junit] 	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
    [junit] 	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
    [junit] 	at java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:434)
    [junit] 	at java.nio.file.Files.newOutputStream(Files.java:216)
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.FormatterElement$DelayedFileOutputStream.write(FormatterElement.java:379)
    [junit] 	at java.io.OutputStream.write(OutputStream.java:116)
    [junit] 	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221)
    [junit] 	at sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:291)
    [junit] 	at sun.nio.cs.StreamEncoder.implFlush(StreamEncoder.java:295)
    [junit] 	at sun.nio.cs.StreamEncoder.flush(StreamEncoder.java:141)
    [junit] 	at java.io.OutputStreamWriter.flush(OutputStreamWriter.java:229)
    [junit] 	at java.io.BufferedWriter.flush(BufferedWriter.java:254)
    [junit] 	at org.apache.tools.ant.util.DOMElementWriter.openElement(DOMElementWriter.java:368)
    [junit] 	at org.apache.tools.ant.util.DOMElementWriter.write(DOMElementWriter.java:209)
    [junit] 	at org.apache.tools.ant.util.DOMElementWriter.write(DOMElementWriter.java:222)
    [junit] 	at org.apache.tools.ant.util.DOMElementWriter.write(DOMElementWriter.java:222)
    [junit] 	at org.apache.tools.ant.taskdefs.optional.junit.XMLJUnitResultFormatter.endTestSuite(XMLJUnitResultFormatter.java:195)
    [junit] 	... 4 more
```