### PR TITLE
Memoize reflection

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -54,11 +54,6 @@ java.lang.instrument.Instrumentation.getObjectSize, which only claims
 to provide "approximate" results, but in practice seems to work as
 expected.
 
-MemoryMeter uses reflection to crawl the object graph for measureDeep.
-Reflection is slow: measuring a one-million object Cassandra Memtable
-(that is, 1 million children from MemoryMeter.countChildren) took
-about 5 seconds wall clock time.
-
 By default, MemoryMeter keeps track of descendants visited by
 measureDeep with an IdentityHashMap.  This prevents both over-counting
 and infinite loops due to cycles in the object graph.  Of course, this

--- a/build.xml
+++ b/build.xml
@@ -66,7 +66,7 @@
 
   <target depends="init" name="build">
     <echo message="${ant.project.name}: ${ant.file}"/>
-    <javac source="7" target="7" debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" includeantruntime="false">
+    <javac source="8" target="8" debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" includeantruntime="false">
       <src path="${build.src}"/>
       <compilerarg value="-XDignore.symbol.file"/>
     </javac>
@@ -83,7 +83,7 @@
   </target>
 
   <target name="build-test" depends="jar" description="Compile test classes">
-    <javac source="7" target="7" debug="true" debuglevel="${debuglevel}" destdir="${test.classes}" includeantruntime="false">
+    <javac source="8" target="8" debug="true" debuglevel="${debuglevel}" destdir="${test.classes}" includeantruntime="false">
       <classpath>
         <path refid="autoivy.classpath"/>
         <pathelement location="${build.classes}"/>

--- a/build.xml
+++ b/build.xml
@@ -66,7 +66,7 @@
 
   <target depends="init" name="build">
     <echo message="${ant.project.name}: ${ant.file}"/>
-    <javac source="1.6" target="1.6" debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" includeantruntime="false">
+    <javac source="7" target="7" debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" includeantruntime="false">
       <src path="${build.src}"/>
       <compilerarg value="-XDignore.symbol.file"/>
     </javac>
@@ -83,7 +83,7 @@
   </target>
 
   <target name="build-test" depends="jar" description="Compile test classes">
-    <javac source="1.6" target="1.6" debug="true" debuglevel="${debuglevel}" destdir="${test.classes}" includeantruntime="false">
+    <javac source="7" target="7" debug="true" debuglevel="${debuglevel}" destdir="${test.classes}" includeantruntime="false">
       <classpath>
         <path refid="autoivy.classpath"/>
         <pathelement location="${build.classes}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>7</source>
+          <target>7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>7</source>
-          <target>7</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Memoizes slow reflective operations into `ClassValue` objects. Most notably, creation of a list of accessible, non-primitive `Field` objects that need to be traversed in `measureDeep` and `countChildren`. It also memoizes `MemoryLayoutSpecification.sizeOfInstance[WithUnsafe]` as both of those also need to retrieve a list of fields.

A separate commit bumps the required version of Java to 7, since that's when `java.lang.ClassValue` was introduced.