### PR TITLE
Add support for Java 18 to 21 (fixes #52)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,50 @@
               </jdkToolchain>
             </configuration>
           </execution>
+          <execution>
+            <id>test-jdk18</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <jdkToolchain>
+                <version>18</version>
+              </jdkToolchain>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-jdk19</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <jdkToolchain>
+                <version>19</version>
+              </jdkToolchain>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-jdk20</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <jdkToolchain>
+                <version>20</version>
+              </jdkToolchain>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-jdk21</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <jdkToolchain>
+                <version>21</version>
+              </jdkToolchain>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/test/org/github/jamm/MemoryMeterTest.java
+++ b/test/org/github/jamm/MemoryMeterTest.java
@@ -482,7 +482,7 @@ public class MemoryMeterTest {
      * Returns the package-private field {@code ReferenceQueue.NULL} (which is the default used when
      * a Reference is created without an explicit queue).
      * <br/>
-     * In earlier JDK versions, this used to be equivalent to {@code new ReferenceQueue<Object>{}}.
+     * In earlier JDK versions, this used to be equivalent to {@code new ReferenceQueue<Object>()}.
      * However, starting with JDK 19, it uses an optimized implementation that nulls out some
      * internal fields to save space, resulting in a different size.
      */

--- a/test/org/github/jamm/MemoryMeterTest.java
+++ b/test/org/github/jamm/MemoryMeterTest.java
@@ -1,13 +1,16 @@
 package org.github.jamm;
 
 import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.function.Predicate;
 
+import org.github.jamm.accessors.FieldAccessor;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -149,16 +152,17 @@ public class MemoryMeterTest {
         assertEquals(refShallowSize,  meterIgnoring.measureDeep(ref));
 
         // SoftReference + deep queue + referent
-        long deepSize = refShallowSize + meterMeasuring.measureDeep(new ReferenceQueue<Object>()) + meterMeasuring.measure(new Date());
-        assertEquals(deepSize,  meterMeasuring.measureDeep(ref));
+        ReferenceQueue<?> nullReferenceQueue = getNullReferenceQueue();
+        long deepSize = refShallowSize + meterMeasuring.measureDeep(nullReferenceQueue) + meterMeasuring.measure(new Date());
+        assertEquals(deepSize, meterMeasuring.measureDeep(ref));
 
         HasReferenceField hasReferenceField = new HasReferenceField(ref);
         long hasReferenceFieldShallowSize = meterIgnoring.measure(hasReferenceField);
         assertEquals(refShallowSize + hasReferenceFieldShallowSize, meterIgnoring.measureDeep(hasReferenceField));
 
         // HasReferenceField + SoftReference + deep queue + referent
-        deepSize = hasReferenceFieldShallowSize + refShallowSize + meterMeasuring.measureDeep(new ReferenceQueue<Object>()) + meterMeasuring.measure(new Date());
-        assertEquals(deepSize,  meterMeasuring.measureDeep(hasReferenceField));
+        deepSize = hasReferenceFieldShallowSize + refShallowSize + meterMeasuring.measureDeep(nullReferenceQueue) + meterMeasuring.measure(new Date());
+        assertEquals(deepSize, meterMeasuring.measureDeep(hasReferenceField));
 
         // Test ReferenceQueue measurement with one object
         ReferenceQueue<Object> queue = new ReferenceQueue<>();
@@ -179,9 +183,9 @@ public class MemoryMeterTest {
 
         Assert.assertTrue(p.isEnqueued());
 
-        long queueShallowSize = meterIgnoring.measure(queue);
-        long lockSize = meterIgnoring.measure(new Object()); // The ReferenceQueue lock field has the same size as an empty object.
-        assertEquals(queueShallowSize + lockSize,  meterIgnoring.measureDeep(queue));
+        // The queue contains one reference that isn't strong (so ignored), so it should measure the
+        // same as an empty queue.
+        assertEquals(meterIgnoring.measureDeep(new ReferenceQueue<>()), meterIgnoring.measureDeep(queue));
 
         assertEquals(p, queue.poll());
     }
@@ -471,6 +475,24 @@ public class MemoryMeterTest {
             hasAddChildrenBeenUsed = true;
 
             stack.pushObject(this, "name", name);
+        }
+    }
+
+    /**
+     * Returns the package-private field {@code ReferenceQueue.NULL} (which is the default used when
+     * a Reference is created without an explicit queue).
+     * <br/>
+     * In earlier JDK versions, this used to be equivalent to {@code new ReferenceQueue<Object>{}}.
+     * However, starting with JDK 19, it uses an optimized implementation that nulls out some
+     * internal fields to save space, resulting in a different size.
+     */
+    private static ReferenceQueue<?> getNullReferenceQueue() {
+        try {
+            SoftReference<Object> ref = new SoftReference<>(null);
+            Field field = Reference.class.getDeclaredField("queue");
+            return (ReferenceQueue<?>) FieldAccessor.newInstance().getFieldValue(ref, field);
+        } catch (NoSuchFieldException e) {
+            throw new AssertionError("Expected to access Reference.queue via reflection", e);
         }
     }
 }

--- a/toolchains.example.xml
+++ b/toolchains.example.xml
@@ -31,4 +31,44 @@
       <jdkHome>/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home</jdkHome>
     </configuration>
   </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>18</version>
+      <vendor>Oracle Corporation</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/Library/Java/JavaVirtualMachines/jdk-18.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>19</version>
+      <vendor>Oracle Corporation</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/Library/Java/JavaVirtualMachines/jdk-19.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>20</version>
+      <vendor>Oracle Corporation</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/Library/Java/JavaVirtualMachines/jdk-20.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>21</version>
+      <vendor>Oracle Corporation</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
 </toolchains>


### PR DESCRIPTION
Tested on MacOS with Oracle versions 18.0.2.1, 19.0.2, 20.0.2 and 21.0.5 (arm64).

This only fixes issues that were detected by existing tests.
